### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ Out of the box, a copy of this repository requires only that the debug adapter (
 To build the debug adapter, you can either use the built-in Nova tasks for the DebugAdapter subproject directory or invoke SwiftPM directly:
 
 ```shell
+cd DebugAdaptor
 swift build --product LLDBAdapter --configuration release
-cp .build/release/LLDBAdapter ../Executables/LLDBAdapter
+cp .build/release/LLDBAdapter ../Icarus.novaextension/Executables/LLDBAdaptor
 ```
 
 Once this is done, the extension bundle can be loaded into Nova as a development extension for testing.


### PR DESCRIPTION
The command line instructions didn't work as written.  Updated to make them work.


That said, I'm getting an error when I open `Icarus/Icarus.novaextension` after building and executing the updated commands:

- build the DebugAdaptor:

```
cd DebugAdaptor
swift build --product LLDBAdapter --configuration release
cp .build/release/LLDBAdapter ../Icarus.novaextension/Executables/LLDBAdaptor
```

![Screenshot 2023-08-06 at 11 31 25 PM](https://github.com/haikusw/icarus/assets/222271/a2f93bf1-908b-41d0-8968-7b95d15cc3d8)

But I think this may be because Icarus uses:

```
function debugAdapterPath() {
    let adapterPath = nova.path.normalize(nova.path.join(nova.extension.path, "Executables/LLDBAdapter"));
    
    // Check adapter executability.
    if (!nova.fs.access(adapterPath, nova.fs.constants.X_OK)) {
        // Set +x on the adapter to get around an issue with extensions being installed by Nova.
        nova.fs.chmod(adapterPath, 0o755);
    }
    
    return adapterPath;
}
```


which maybe doesn't work for an extension project activated via "Activate Project As Extension" in the "Extensions" menu?